### PR TITLE
Kafka 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.vladmihalcea:hibernate-types-52:2.17.3'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/sol/sns/consumer/AlarmConsumer.java
+++ b/src/main/java/com/sol/sns/consumer/AlarmConsumer.java
@@ -1,0 +1,24 @@
+package com.sol.sns.consumer;
+
+import com.sol.sns.model.event.AlarmEvent;
+import com.sol.sns.service.AlarmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlarmConsumer {
+
+    private final AlarmService alarmService;
+
+    @KafkaListener(topics = "${spring.kafka.topic.notification}")
+    public void consumeAlarm(AlarmEvent event, Acknowledgment ack) {
+        log.info("Consume the event {}", event);
+        alarmService.send(event.getAlarmType(), event.getArgs() , event.getReceiveUserId());
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/com/sol/sns/model/AlarmArgs.java
+++ b/src/main/java/com/sol/sns/model/AlarmArgs.java
@@ -2,9 +2,11 @@ package com.sol.sns.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class AlarmArgs {
 
     // 알람을 발생시킨 사람

--- a/src/main/java/com/sol/sns/model/event/AlarmEvent.java
+++ b/src/main/java/com/sol/sns/model/event/AlarmEvent.java
@@ -1,0 +1,16 @@
+package com.sol.sns.model.event;
+
+import com.sol.sns.model.AlarmArgs;
+import com.sol.sns.model.AlarmType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlarmEvent {
+    private Integer receiveUserId;
+    private AlarmType alarmType;
+    private AlarmArgs args;
+}

--- a/src/main/java/com/sol/sns/producer/AlarmProducer.java
+++ b/src/main/java/com/sol/sns/producer/AlarmProducer.java
@@ -1,0 +1,25 @@
+package com.sol.sns.producer;
+
+import com.sol.sns.model.event.AlarmEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlarmProducer {
+
+    private final KafkaTemplate<Integer, AlarmEvent> kafkaTemplate;
+
+    @Value("${spring.kafka.topic.notification}")
+    private String topic;
+
+    public void send(AlarmEvent event) {
+        log.info("topic: {}", topic);
+        kafkaTemplate.send(topic, event.getReceiveUserId(), event);
+        log.info("Send to Kafka finished");
+    }
+}

--- a/src/main/java/com/sol/sns/service/AlarmService.java
+++ b/src/main/java/com/sol/sns/service/AlarmService.java
@@ -2,7 +2,13 @@ package com.sol.sns.service;
 
 import com.sol.sns.exception.ErrorCode;
 import com.sol.sns.exception.SnsApplicationException;
+import com.sol.sns.model.AlarmArgs;
+import com.sol.sns.model.AlarmType;
+import com.sol.sns.model.entity.AlarmEntity;
+import com.sol.sns.model.entity.UserEntity;
+import com.sol.sns.repository.AlarmEntityRepository;
 import com.sol.sns.repository.EmitterRepository;
+import com.sol.sns.repository.UserEntityRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,16 +24,21 @@ public class AlarmService {
     private final static Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
     private final static String ALARM_NAME = "alarm";
     private final EmitterRepository emitterRepository;
+    private final AlarmEntityRepository alarmEntityRepository;
+    private final UserEntityRepository userEntityRepository;
 
-    public void send(Integer alarmId, Integer userId) {
-        emitterRepository.get(userId).ifPresentOrElse(sseEmitter -> {
+    public void send(AlarmType type, AlarmArgs arg, Integer receiverUserId) {
+        UserEntity user = userEntityRepository.findById(receiverUserId).orElseThrow(() -> new SnsApplicationException(ErrorCode.USER_NOT_FOUND));
+        AlarmEntity alarmEntity = alarmEntityRepository.save(AlarmEntity.of(user, type,  arg));
+
+        emitterRepository.get(receiverUserId).ifPresentOrElse(sseEmitter -> {
             try {
                 sseEmitter.send(SseEmitter.event()
-                        .id(alarmId.toString())
+                        .id(alarmEntity.getId().toString())
                         .name(ALARM_NAME)
                         .data("new alarm"));
             } catch (IOException e) {
-                emitterRepository.delete(userId);
+                emitterRepository.delete(receiverUserId);
                 throw new SnsApplicationException(ErrorCode.ALARM_CONNECT_ERROR);
             }
         }, () -> log.info("No emitter found"));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,3 +19,26 @@ jwt:
   token.expired-time-ms: 2592000000
 
 spring.redis.url: ${REDIS_URL}
+
+spring:
+  kafka:
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: SCRAM-SHA-256
+      sasl.jaas.config: org.apache.kafka.common.security.scram.ScramLoginModule required username="${KAFKA_USERNAME}" password="${KAFKA_PW}";
+    consumer:
+      properties.spring.json.trusted.packages: "*"
+      bootstrap-servers: moped.srvs.cloudkafka.com:9094
+      group-id: kqdravip-notification
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.IntegerDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    listener:
+      ack-mode: MANUAL
+    producer:
+      bootstrap-servers: moped.srvs.cloudkafka.com:9094
+      key-serializer: org.apache.kafka.common.serialization.IntegerSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties.enable.idempotence: false
+    topic:
+      notification: kqdravip-notification


### PR DESCRIPTION
알람을 보내는 동작자체는 `like`, `comment` API 의 호출 완료까지 반드시 일어나야하는 일은 아님
하지만, Kafka를 도입하기 전에는 `like`, `comment` API와 알람은 강하게 결합되어 있는 상태였다.
강하게 결합되어 있는 상태를 유지하면, 알람 보내는 부분에 문제가 있어서 지연이 발생할 때, `like`, `comment` API도 동작을 제대로 하지 않게 된다. 따라서, 결합도를 낮추기 위해 비동기적으로 처리하는 `Kafka`를 도입한다. 